### PR TITLE
Fix 0 AM midnight bug (12-hour clock)

### DIFF
--- a/src/scripts/components/colour/Time.js
+++ b/src/scripts/components/colour/Time.js
@@ -5,10 +5,12 @@ import { TimeHelper } from '../../modules/timehelper';
 export const Time = (props) => {
   const time = props.time;
 
-  var hour = time.hour;
+  var hour = parseInt(time.hour);
 
-  if (!props.hourFormat24 && time.pm) {
-    hour -= 12;
+  if (!props.hourFormat24) {
+    if (time.pm) {
+      hour -= 12;
+    }
     hour = TimeHelper.pad(hour === 0 ? 12 : hour);
   }
 


### PR DESCRIPTION
Using 12-hour clock, time shows 0 (instead of 12) between 12 and 1 AM.

<img src="https://cloud.githubusercontent.com/assets/8116382/15812623/23b3b4fe-2b85-11e6-933c-b448a8557fd4.png" width="550px"/>